### PR TITLE
Add 'fslview' displaySpace, and change orientation warnings behavior

### DIFF
--- a/fsleyes/controls/locationpanel.py
+++ b/fsleyes/controls/locationpanel.py
@@ -904,7 +904,10 @@ class LocationInfoPanel(fslpanel.FSLeyesPanel):
 
         for i in images[1:]:
             if not i.sameSpace(images[0]):
-                return strings.messages[self, 'displaySpaceWarning']
+                if not self.displayCtx.hideOrientationWarnings and (self.displayCtx.displaySpace == 'scaledVoxels' or self.displayCtx.displaySpace == 'fslview'):
+                    return strings.messages[self, 'displaySpaceWarningPixdim']
+                else:
+                    return strings.messages[self, 'displaySpaceWarning']
 
         return None
 

--- a/fsleyes/displaycontext/display.py
+++ b/fsleyes/displaycontext/display.py
@@ -572,7 +572,7 @@ class DisplayOpts(props.SyncableHasProperties, actions.ActionProvider):
         # orientation labels, as there's no guarantee
         # that all of the loaded overlays are in the
         # same orientation, and it can get confusing.
-        if opts.transform in ('id', 'pixdim', 'pixdim-flip') and \
+        if opts.transform in ('id') and \
            self.displayCtx.displaySpace != refImage:
             xlo = 'Xmin'
             xhi = 'Xmax'

--- a/fsleyes/displaycontext/displaycontext.py
+++ b/fsleyes/displaycontext/displaycontext.py
@@ -163,7 +163,7 @@ class DisplayContext(props.SyncableHasProperties):
     """
 
 
-    displaySpace = props.Choice(('world', 'scaledVoxel'))
+    displaySpace = props.Choice(('world', 'scaledVoxel','fslview'))
     """The *space* in which overlays are displayed. This property defines the
     display coordinate system for this ``DisplayContext``. When it is changed,
     the :attr:`.NiftiOpts.transform` property of all :class:`.Nifti` overlays
@@ -242,6 +242,10 @@ class DisplayContext(props.SyncableHasProperties):
               or less memory-intensive manner.
     """
 
+    hideOrientationWarnings = props.Boolean(default=False)
+    """If ``True``, do not display warnings when displayed anatomical
+    labels may be incorrect
+    """
 
     def __init__(self,
                  overlayList,
@@ -557,6 +561,9 @@ class DisplayContext(props.SyncableHasProperties):
         elif space == 'scaledVoxel':
             space    = self.getSelectedOverlay()
             srcSpace = 'pixdim'
+        elif space == 'fslview':
+            space    = self.getSelectedOverlay()
+            srcSpace = 'pixdim-flip'
         else:
             srcSpace = 'pixdim-flip'
 
@@ -698,7 +705,7 @@ class DisplayContext(props.SyncableHasProperties):
 
         :arg ds: Either ``'ref'``, ``'scaledVoxel'``, or ``'world'``.
         """
-        if ds not in ('world', 'scaledVoxel', 'ref'):
+        if ds not in ('world', 'scaledVoxel', 'ref','fslview'):
             raise ValueError('Invalid default display space: {}'.format(ds))
         self.__defaultDisplaySpace = ds
 
@@ -898,7 +905,7 @@ class DisplayContext(props.SyncableHasProperties):
             if isinstance(overlay, fslimage.Nifti):
                 choices.append(overlay)
 
-        choices.extend(('world', 'scaledVoxel'))
+        choices.extend(('world', 'scaledVoxel','fslview'))
 
         choiceProp.setChoices(choices, instance=self)
 
@@ -927,6 +934,7 @@ class DisplayContext(props.SyncableHasProperties):
         with props.skip(opts, 'bounds', self.__name, ignoreInvalid=True):
             if   space == 'world':       opts.transform = 'affine'
             elif space == 'scaledVoxel': opts.transform = 'pixdim'
+            elif space == 'fslview':     opts.transform = 'pixdim-flip'
             elif image is space:         opts.transform = 'pixdim-flip'
             else:                        opts.transform = 'reference'
 
@@ -1194,6 +1202,9 @@ class DisplayContext(props.SyncableHasProperties):
         if self.displaySpace == 'scaledVoxel':
             ref      = self.getSelectedOverlay()
             srcSpace = 'pixdim'
+        elif self.displaySpace == 'fslview':
+            ref      = self.getSelectedOverlay()
+            srcSpace = 'pixdim-flip'
         else:
             ref      = self.displaySpace
             srcSpace = 'display'

--- a/fsleyes/displaycontext/niftiopts.py
+++ b/fsleyes/displaycontext/niftiopts.py
@@ -447,6 +447,8 @@ class NiftiOpts(fsldisplay.DisplayOpts):
             voxToRefMat = voxToWorldMat
         elif ds == 'scaledVoxel':
             voxToRefMat = voxToPixdimMat
+        elif ds == 'fslview':
+            voxToRefMat = voxToPixFlipMat
         elif ds is self.overlay:
             voxToRefMat = voxToPixFlipMat
         else:

--- a/fsleyes/parseargs.py
+++ b/fsleyes/parseargs.py
@@ -402,6 +402,7 @@ OPTIONS = td.TypeDict({
                        'autoDisplay',
                        'displaySpace',
                        'neuroOrientation',
+                       'hideOrientationWarnings',
                        'standard',
                        'standard_brain',
                        'standard1mm',
@@ -791,6 +792,7 @@ ARGUMENTS = td.TypeDict({
     'Main.autoDisplay'         : ('ad',      'autoDisplay',         False),
     'Main.displaySpace'        : ('ds',      'displaySpace',        True),
     'Main.neuroOrientation'    : ('no',      'neuroOrientation',    False),
+    'Main.hideOrientationWarnings' : ('now',      'hideOrientationWarnings',    False),
     'Main.standard'            : ('std',     'standard',            False),
     'Main.standard_brain'      : ('stdb',    'standard_brain',      False),
     'Main.standard1mm'         : ('std1mm',  'standard1mm',         False),
@@ -1044,7 +1046,12 @@ HELP = td.TypeDict({
                               'settings (unless any display settings are '
                               'specified)',
     'Main.displaySpace'     : 'Space in which all overlays are displayed - '
-                              'can be "world", or a NIFTI image.',
+                              'can be "world","scaledVoxels",'
+                              '"fslview" (fslview-compatible approach), '
+                              'or a NIFTI image.',
+    'Main.hideOrientationWarnings' : 'Hides warnings in situations where '
+                              'displayed anatomical orientation may be be '
+                              'incorrect',
     'Main.neuroOrientation' : 'Display images in neurological orientation '
                               '(default: radiological)',
 
@@ -1753,6 +1760,7 @@ def _configMainParser(mainParser, exclude=None):
                                  'type'    : int},
         'neuroOrientation'    : {'action'  : 'store_true'},
         'displaySpace'        : {'type'    : str},
+        'hideOrientationWarnings' : {'action'  : 'store_true'},
         'standard'            : {'action'  : 'store_true'},
         'standard_brain'      : {'action'  : 'store_true'},
         'standard1mm'         : {'action'  : 'store_true'},
@@ -2610,6 +2618,9 @@ def applyMainArgs(args, overlayList, displayCtx):
     if args.bigmem is not None:
         displayCtx.loadInMemory = args.bigmem
 
+    if args.hideOrientationWarnings is not None:
+        displayCtx.hideOrientationWarnings = args.hideOrientationWarnings
+
     if args.neuroOrientation is not None:
         displayCtx.radioOrientation = not args.neuroOrientation
 
@@ -2686,6 +2697,8 @@ def applySceneArgs(args, overlayList, displayCtx, sceneOpts):
             displaySpace = 'world'
         elif args.displaySpace == 'scaledVoxel':
             displaySpace = 'scaledVoxel'
+        elif args.displaySpace == 'fslview':
+            displaySpace = 'fslview'
 
         elif args.displaySpace is not None:
             try:

--- a/fsleyes/strings.py
+++ b/fsleyes/strings.py
@@ -84,6 +84,8 @@ messages = TypeDict({
 
     'LocationInfoPanel.displaySpaceWarning' :
     'Displaying images with different orientations/fields of view!',
+    'LocationInfoPanel.displaySpaceWarningPixdim' :
+    'Warning: anatomical labels may not be correct!',
 
     'LoadColourMapAction.loadcmap'    : 'Open colour map file',
     'LoadColourMapAction.namecmap'    : 'Enter a name for the colour map.',
@@ -1297,6 +1299,7 @@ choices = TypeDict({
 
     'DisplayContext.displaySpace' : {'world'       : 'World coordinates',
                                      'scaledVoxel' : 'Scaled voxel coordinates',
+                                     'fslview'     : 'fslview-compatible (pixdim-flip)'
                                      },
 
     'SceneOpts.colourBarLocation'  : {'top'          : 'Top',


### PR DESCRIPTION
Add 'fslview' displaySpace, and change orientation warnings behavior
    * fslview-compatible displaySpace uses pixdim-flip, similar to fslview/fsl coordinate space behavior
    * Orientation labels are now displayed when in pixdim (scaledVoxels) or pixdim-flip (fslview) spaces, but a warning is displayed that they may be incorrect.
    * This warning may be suppressed with a new --hideOrientationWarnings

This is similar to https://github.com/pauldmccarthy/fsleyes/issues/84, but for our case we needed pixdim-flip rather than pixdim (scaledVoxels). We are doing a direct migration of workflows from fslview, and some of the images are in old, frozen databases where nii orientations are not consistent and it was never noticed in fslview, but fixing all the affected images at this point would be a burden, so we are seeking an option to use the old fslview-like behavior in this circumstance. We also weren't quite satisfied with the behavior of changing the orientation labels during scaledVoxels, as we know these labels are correct for our images.

From discussing with Paul over email, he suggested that we could display the anatomical orientation labels with a warning that they may be incorrect, and also add a --hideOrientationWarnings that could suppress this warning. I wasn't entirely clear whether this was intended to also suppress the original "displaying images with different orientations" warning. At this point, I only suppressed the new warning, which reverts to the old warning in most of the cases where it would have appeared.

Thanks for your consideration! I am happy to iterate on this. I also wasn't sure whether to keep it as "fslview" space, or change to "fsl" space, as you suggested that fslview's behavior is really the same across all fsl. I can change it if you prefer.

Chris Schwarz
Mayo Clinic
