### PR TITLE
Add ctrl+shift+f hotkey: toggle all overlays > 1

### DIFF
--- a/fsleyes/actions/frameactions.py
+++ b/fsleyes/actions/frameactions.py
@@ -129,6 +129,23 @@ def toggleOverlayVisibility(self, *args, **kwargs):
 
     display.enabled = not display.enabled
 
+def toggleOverlaysVisibility(self, *args, **kwargs):
+    """Toggles visibility of all images except the first image on the list. """
+
+    overlayList = self.overlayList
+
+    if len(overlayList) in (0, 1):
+        return
+
+    viewPanel = self.focusedViewPanel
+
+    if viewPanel is None: displayCtx = self     .displayCtx
+    else:                 displayCtx = viewPanel.displayCtx
+
+    for i in range(1,len(overlayList)):
+        o = overlayList[displayCtx.overlayOrder[i]]
+        display = displayCtx.getDisplay(o)
+        display.enabled = not display.enabled
 
 def openHelp(self, *args, **kwargs):
     """Opens FSLeyes help in a web browser. """
@@ -183,6 +200,7 @@ FSLeyesFrame.removeFocusedViewPanel  = actions.action(removeFocusedViewPanel)
 FSLeyesFrame.selectNextOverlay       = actions.action(selectNextOverlay)
 FSLeyesFrame.selectPreviousOverlay   = actions.action(selectPreviousOverlay)
 FSLeyesFrame.toggleOverlayVisibility = actions.action(toggleOverlayVisibility)
+FSLeyesFrame.toggleOverlaysVisibility = actions.action(toggleOverlaysVisibility)
 FSLeyesFrame.openHelp                = actions.action(openHelp)
 FSLeyesFrame.setFSLDIR               = actions.action(setFSLDIR)
 FSLeyesFrame.closeFSLeyes            = actions.action(closeFSLeyes)

--- a/fsleyes/frame.py
+++ b/fsleyes/frame.py
@@ -1873,7 +1873,8 @@ class FSLeyesFrame(wx.Frame):
                        SaveOverlayAction,
                        ReloadOverlayAction,
                        RemoveOverlayAction,
-                       'toggleOverlayVisibility']
+                       'toggleOverlayVisibility',
+                       'toggleOverlaysVisibility']
 
         for action in fileActions:
 
@@ -2076,9 +2077,10 @@ class FSLeyesFrame(wx.Frame):
 
         haveOverlays = overlay is not None
 
-        self.selectNextOverlay      .enabled = haveOverlays
-        self.selectPreviousOverlay  .enabled = haveOverlays
-        self.toggleOverlayVisibility.enabled = haveOverlays
+        self.selectNextOverlay       .enabled = haveOverlays
+        self.selectPreviousOverlay   .enabled = haveOverlays
+        self.toggleOverlayVisibility .enabled = haveOverlays
+        self.toggleOverlaysVisibility.enabled = haveOverlays
 
         if not self.__haveMenu:
             return

--- a/fsleyes/profiles/shortcuts.py
+++ b/fsleyes/profiles/shortcuts.py
@@ -38,6 +38,7 @@ actions = td.TypeDict({
     'FSLeyesFrame.selectNextOverlay'       : 'Ctrl-Up',
     'FSLeyesFrame.selectPreviousOverlay'   : 'Ctrl-Down',
     'FSLeyesFrame.toggleOverlayVisibility' : 'Ctrl-F',
+    'FSLeyesFrame.toggleOverlaysVisibility' : 'Ctrl-Shift+F',
 
     # Shortcuts for next/prev volume
 

--- a/fsleyes/strings.py
+++ b/fsleyes/strings.py
@@ -559,6 +559,7 @@ actions = TypeDict({
     'FSLeyesFrame.selectNextOverlay'       : 'Next',
     'FSLeyesFrame.selectPreviousOverlay'   : 'Previous',
     'FSLeyesFrame.toggleOverlayVisibility' : 'Show/hide',
+    'FSLeyesFrame.toggleOverlaysVisibility' : 'Show/hide all but first image',
 
     'ViewPanel.removeAllPanels'             : 'Remove all panels',
     'ViewPanel.removeFromFrame'             : 'Close',


### PR DESCRIPTION
In our homebrew-modified fslview, we came to enjoy a hotkey that simply toggles visibility of all overlays that weren't the bottom-most on the list. Often-times we open a T1 with a bunch of different masks overlaid, and we want to look at one mask at a time. The option to toggle all but the first image sets that up quickly from the starting point of all-images-visible. Another great use case is when you have 1 base image and 2 masks loaded. If one mask is on and the other is off, and you want to toggle, this hotkey flips between the two masks. 

I chose ctrl+shift+f because ctrl+f is already the hotkey for toggling visibility of the current overlay, and ctrl+alt+f is a system-level hotkey in our x2go environment, so that would not be of much use to our group.

Thanks for your consideration!