### PR TITLE
Adds $FSL_SITE_CONFIG_DIR as a place for cmaps and luts

### DIFF
--- a/fsleyes/colourmaps.py
+++ b/fsleyes/colourmaps.py
@@ -310,14 +310,14 @@ def scanBuiltInLuts():
     return _scanMaps(basedir, lutFiles)
 
 
-def getSiteConfigDir(envvar="FSL_SITE_CONFIG_DIR"):   # -> str, bool
+def getSiteConfigDir(envvar="FSLEYES_SITE_CONFIG_DIR"):   # -> str, bool
     """Return $envvar + whether or not it is a directory."""
     scd = os.environ.get(envvar, '')
     return scd, op.isdir(scd)
 
 
-def fetchFromSiteConfigDir(kind, dirfinder, envvar="FSL_SITE_CONFIG_DIR"):   # -> dict
-    """Returns a dict which is _scanMaps($FSL_SITE_CONFIG_DIR/kind), if it is defined."""
+def fetchFromSiteConfigDir(kind, dirfinder, envvar="FSLEYES_SITE_CONFIG_DIR"):   # -> dict
+    """Returns a dict which is _scanMaps($FSLEYES_SITE_CONFIG_DIR/kind), if it is defined."""
     rv = {}
     scd, have_scd = getSiteConfigDir(envvar)
     if have_scd:


### PR DESCRIPTION
Hi,

Our lab has several custom colo(u)rmaps and luts, and we would like all our users to be able to use them, with custom ordering of the selection menus, without doing any user-level configuration. I had set them up and edited order.txt in fsleyes.assetsdir, which worked until an fsleyes update overwrote the order.txts. It would be much better to have such site configuration outside the FSL/fsleyes installation directories, so this PR gets at least the cmap/lut lookup to check $FSL_SITE_CONFIG_DIR as a possible 3rd location of cmaps, luts, and order.txts.

The priority order is user > site > builtin.

Rob Reid
Mayo Clinic